### PR TITLE
Image urls created in ItemModel.

### DIFF
--- a/xchangeServiceLambda/src/main/java/com/nashss/se/exchange/Models/ItemModel.java
+++ b/xchangeServiceLambda/src/main/java/com/nashss/se/exchange/Models/ItemModel.java
@@ -1,5 +1,6 @@
 package com.nashss.se.exchange.Models;
 
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -21,6 +22,7 @@ public class ItemModel {
         this.type = type;
         this.exchanged = exchanged;
         this.images = images;
+        this.formatImages(images);
         this.email = email;
         this.zipCode = zipCode;
     }
@@ -57,6 +59,18 @@ public class ItemModel {
         return zipCode;
     }
 
+    private Set<String> formatImages(Set<String> imageReferences) {
+        if(imageReferences == null) {
+            return new HashSet<>();
+        }
+        Set<String> imageUrls = new HashSet<>();
+        String s3Bucket = "https://nss-s3-c02-02-u5-project-hillarymartin.s3.us-east-2.amazonaws.com/";
+        for(String reference : imageReferences) {
+            String imageUrl = s3Bucket + reference;
+            imageUrls.add(imageUrl);
+        }
+        return imageUrls;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/xchangeServiceLambda/src/main/java/com/nashss/se/exchange/dynamodb/ItemDao.java
+++ b/xchangeServiceLambda/src/main/java/com/nashss/se/exchange/dynamodb/ItemDao.java
@@ -41,8 +41,6 @@ public class ItemDao {
 //        return null;
 //    }
 
-
-
     public Boolean deleteItem(Item item) {
         if (item == null ){
             throw new IllegalArgumentException("Item cannot be null");


### PR DESCRIPTION
I decided to format the image urls in the ItemModel. In the dao mulitple methods would need to do this, so I could have made it a helper method in the dao. But I ended up making it a part of the ItemModel, since I figured Item model was supposed to create the returned item and each image reference just needs an S3 bucket reference. I can move it later if needed, but for now that's where I thought it best fit. 

